### PR TITLE
react-native-web-modal already has different entry points to server c…

### DIFF
--- a/components/modal.js
+++ b/components/modal.js
@@ -1,3 +1,3 @@
-import { Modal } from 'react-native';
+import Modal from 'react-native-web-modal';
 
 export default Modal;

--- a/components/modal.web.js
+++ b/components/modal.web.js
@@ -1,3 +1,0 @@
-import Modal from 'react-native-web-modal';
-
-export default Modal;


### PR DESCRIPTION
Because react-native-web-modal already imports the correct model impl per platform, we did not need to have the same logic duplicated in this module.